### PR TITLE
fail-on-error does not work correctly when use-reviewdog is enabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
       id: pipe
       if: inputs.use-reviewdog != 'false'
       run: |
-        echo 'PIPE=| reviewdog -name=${{ inputs.reviewdog-tool-name }} -f=golint -filter-mode="${{ inputs.reviewdog-filter-mode }}" --reporter=${{ inputs.reviewdog-reporter }} --tee' >> "$GITHUB_OUTPUT"
+        echo 'PIPE=| reviewdog -name=${{ inputs.reviewdog-tool-name }} -f=golint -filter-mode="${{ inputs.reviewdog-filter-mode }}" --reporter=${{ inputs.reviewdog-reporter }} --fail-on-error=true --tee' >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Set fail-on-error
       id: failonerror


### PR DESCRIPTION
https://github.com/k1LoW/runn/blob/main/.github/workflows/ci.yml#L38
https://github.com/k1LoW/runn/actions/runs/6257717069/job/16990484178#step:7:102

Errors are present, but CI has not failed.