### PR TITLE
fix: update reviewdog installation to use action-setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,8 +92,9 @@ runs:
       shell: bash
     - name: Install reviewdog
       if: inputs.use-reviewdog != 'false'
-      run: go install github.com/reviewdog/reviewdog/cmd/reviewdog@${{ inputs.reviewdog-version }}
-      shell: bash
+      uses: reviewdog/action-setup@d8edfce3dd5e1ec6978745e801f9c50b5ef80252 # v1.4.0
+      with:
+        reviewdog_version: ${{ inputs.reviewdog-version }}
     - name: Set flags
       id: flags
       run: |


### PR DESCRIPTION
This pull request updates the way `reviewdog` is installed in the workflow to use the official `reviewdog/action-setup` GitHub Action instead of installing it directly with `go install`. This change improves reliability and maintainability by leveraging a supported setup action.

**CI/CD workflow improvements:**

* Updated the `Install reviewdog` step in `action.yml` to use `reviewdog/action-setup@v1.4.0` with the `reviewdog_version` input, replacing the previous `go install` approach.